### PR TITLE
Consumer refactor

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -64,7 +64,7 @@ type claim struct {
 	//
 	// offsetLatest is 12, which is the offset that Kafka will assign to the message
 	// that next gets committed to the partition. This offset does not yet exist,
-	// and mit might never.
+	// and might never.
 	offsetCurrent  int64
 	offsetEarliest int64
 	offsetLatest   int64

--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -117,8 +117,7 @@ func newClaim(topic string, partID int, marshal *Marshaler) *claim {
 func (c *claim) updateOffsetsLoop() {
 	ctr := 0
 	for c.Claimed() {
-		jitter := c.rand.Intn(HeartbeatInterval/2) + (HeartbeatInterval / 2)
-		time.Sleep(time.Duration(jitter) * time.Second)
+		time.Sleep(<-c.marshal.jitters)
 		c.updateOffsets(ctr)
 		ctr++
 	}
@@ -325,12 +324,7 @@ func (c *claim) healthCheck() bool {
 // a claimed partition
 func (c *claim) healthCheckLoop() {
 	for c.Claimed() {
-		// We need to health check more often than the heartbeat, but we need to jitter so that
-		// releases don't get synchronized across the fleet. This jitters for 50-100% of the
-		// heartbeat interval.
-		jitter := c.rand.Intn(HeartbeatInterval/2) + (HeartbeatInterval / 2)
-		time.Sleep(time.Duration(jitter) * time.Second)
-
+		time.Sleep(<-c.marshal.jitters)
 		if c.healthCheck() {
 			go c.heartbeat()
 		}

--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -1,0 +1,372 @@
+/*
+ * portal - marshal
+ *
+ * a library that implements an algorithm for doing consumer coordination within Kafka, rather
+ * than using Zookeeper or another external system.
+ *
+ */
+
+package marshal
+
+import (
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/optiopay/kafka"
+	"github.com/optiopay/kafka/proto"
+)
+
+// claim is instantiated for each partition "claim" we have. This type is responsible for
+// pulling data from Kafka and managing its cursors, heartbeating as necessary, and health
+// checking itself.
+type claim struct {
+	// These items are read-only. They are never changed after the object is created,
+	// so access to these may be done without the lock.
+	topic  string
+	partID int
+
+	// lock protects all access to the member variables of this struct except for the
+	// messages channel, which can be read from or written to without holding the lock.
+	lock          sync.RWMutex
+	marshal       *Marshaler
+	rand          *rand.Rand
+	claimed       *int32
+	lastHeartbeat int64
+	consumer      kafka.Consumer
+	messages      chan *proto.Message
+
+	// Number of heartbeat cycles this claim has been lagging, i.e., consumption is going
+	// too slowly (defined as being behind by more than 2 heartbeat cycles)
+	cyclesBehind int
+
+	// A Kafka partition consists of N messages with offsets. In the basic case, you
+	// can think of an offset like an array index. With log compaction and other trickery
+	// it acts more like a sparse array, but it's a close enough metaphor.
+	//
+	// We keep track of four values for offsets:
+	//
+	//    offsets       1     2     3     7     9    10    11
+	//   partition  [ msg1, msg2, msg3, msg4, msg5, msg6, msg7, ... ]
+	//                 ^                  ^                      ^
+	//                 \- offsetEarliest  |                      |
+	//                                    \- offsetCurrent   offsetLatest
+	//                                     and startOffset
+	//
+	// In this example, offsetEarliest is 1 which is the "oldest" offset within the
+	// partition. At any given time this offset might become invalid (if a log rolls)
+	// so we might update it. startOffset is simply the value of offsetCurrent at
+	// the very beginning of consumption (for tracking velocity).
+	//
+	// offsetCurrent is 7, which is the offset of the NEXT message i.e. this message
+	// has not been consumed yet.
+	//
+	// offsetLatest is 12, which is the offset that Kafka will assign to the message
+	// that next gets committed to the partition. This offset does not yet exist,
+	// and mit might never.
+	offsetCurrent  int64
+	offsetEarliest int64
+	offsetLatest   int64
+
+	// History arrays used for calculating average veolocity for health checking.
+	offsetCurrentHistory [10]int64
+	offsetLatestHistory  [10]int64
+}
+
+// newClaim returns an internal claim object, used by the consumer to manage the
+// claim of a single partition.
+func newClaim(topic string, partID int, marshal *Marshaler) *claim {
+	// Get all available offset information
+	oEarly, oLate, oCur, err := marshal.GetPartitionOffsets(topic, partID)
+	if err != nil {
+		log.Errorf("%s:%d failed to get offsets: %s", topic, partID, err)
+		return nil
+	}
+	log.Debugf("%s:%d consumer offsets: early = %d, cur = %d, late = %d",
+		topic, partID, oEarly, oCur, oLate)
+
+	// Construct object and set it up
+	obj := &claim{
+		marshal:        marshal,
+		topic:          topic,
+		partID:         partID,
+		claimed:        new(int32),
+		offsetEarliest: oEarly,
+		offsetLatest:   oLate,
+		offsetCurrent:  oCur,
+		messages:       make(chan *proto.Message, 100),
+		rand:           rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+	atomic.StoreInt32(obj.claimed, 1)
+
+	// Now try to actually claim it, this can block a while
+	log.Infof("%s:%d consumer attempting to claim", topic, partID)
+	if !marshal.ClaimPartition(topic, partID) {
+		log.Infof("%s:%d consumer failed to claim", topic, partID)
+		return nil
+	}
+
+	// If that worked, kick off the main setup loop and return
+	obj.setup()
+	return obj
+}
+
+// updateOffsets polls Kafka periodically to get information about the partition's
+// state.
+func (c *claim) updateOffsetsLoop() {
+	ctr := 0
+	for {
+		time.Sleep(HeartbeatInterval * time.Second)
+		log.Debugf("%s:%d updating offsets", c.topic, c.partID)
+		c.updateOffsets(ctr)
+		ctr++
+	}
+}
+
+// setup is the initial worker that initializes the claim structure. Until this is done,
+// our internal state is inconsistent.
+func (c *claim) setup() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Of course, if the current offset is greater than the earliest, we must reset
+	// to the earliest known
+	if c.offsetCurrent < c.offsetEarliest {
+		log.Warningf("%s:%d consumer fast-forwarding from %d to %d",
+			c.topic, c.partID, c.offsetCurrent, c.offsetEarliest)
+		c.offsetCurrent = c.offsetEarliest
+	}
+
+	// Since it's claimed, we now want to heartbeat with the last seen offset
+	err := c.marshal.Heartbeat(c.topic, c.partID, c.offsetCurrent)
+	if err != nil {
+		log.Errorf("%s:%d consumer failed to heartbeat: %s", c.topic, c.partID, err)
+		atomic.StoreInt32(c.claimed, 0)
+		return
+	}
+	c.lastHeartbeat = time.Now().Unix()
+
+	// Set up Kafka consumer
+	consumerConf := kafka.NewConsumerConf(c.topic, int32(c.partID))
+	consumerConf.StartOffset = c.offsetCurrent
+	kafkaConsumer, err := c.marshal.kafka.Consumer(consumerConf)
+	if err != nil {
+		log.Errorf("%s:%d consumer failed to create Kafka Consumer: %s",
+			c.topic, c.partID, err)
+		// TODO: There is an optimization here where we could release the partition.
+		// As it stands, we're not doing anything,
+		atomic.StoreInt32(c.claimed, 0)
+		return
+	}
+	c.consumer = kafkaConsumer
+
+	// Start our maintenance goroutines that keep this system healthy
+	go c.updateOffsetsLoop()
+	go c.healthCheckLoop()
+	go c.messagePump()
+
+	// Totally done, let the world know and move on
+	log.Infof("%s:%d Consumer claimed at offset %d (is %d behind)",
+		c.topic, c.partID, c.offsetCurrent, c.offsetLatest)
+}
+
+// Claimed returns whether or not this claim structure is alive and well and believes
+// that it is still an active claim.
+func (c *claim) Claimed() bool {
+	return atomic.LoadInt32(c.claimed) == 1
+}
+
+// Release will invoke our release mechanism if and only if we are still claimed.
+func (c *claim) Release() bool {
+	if !atomic.CompareAndSwapInt32(c.claimed, 1, 0) {
+		return false
+	}
+
+	// Holds the lock through a Kafka transaction, but since we're releasing I think this
+	// is reasonable. Held because of using offsetCurrent below.
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	log.Infof("%s:%d releasing partition claim", c.topic, c.partID)
+	err := c.marshal.ReleasePartition(c.topic, c.partID, c.offsetCurrent)
+	if err != nil {
+		log.Errorf("%s:%d failed to release: %s", c.topic, c.partID, err)
+		return false
+	}
+	return true
+}
+
+// messagePump continuously pulls message from Kafka for this partition and makes them
+// available for consumption.
+func (c *claim) messagePump() {
+	// This method MUST NOT make changes to the claim structure. Since we might
+	// be running while someone else has the lock, and we can't get it ourselves, we are
+	// forbidden to touch anything other than the consumer and the message channel.
+	for {
+		if !c.Claimed() {
+			log.Infof("%s:%d no longer claimed, pump exiting.", c.topic, c.partID)
+			return
+		}
+
+		msg, err := c.consumer.Consume()
+		if err == proto.ErrOffsetOutOfRange {
+			// Fell out of range, presumably because we're handling this too slow, so
+			// let's abandon this consumer
+			log.Errorf("%s:%d error consuming: out of range, abandoning partition",
+				c.topic, c.partID)
+			atomic.StoreInt32(c.claimed, 0)
+			return
+		}
+		if err != nil {
+			log.Errorf("%s:%d error consuming: %s", c.topic, c.partID, err)
+
+			// Often a consumption error is caused by data going away, such as if we're consuming
+			// from the head and Kafka has deleted the data. In that case we need to wait for
+			// the next offset update, so let's not go crazy
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		c.messages <- msg
+	}
+}
+
+// healthCheck performs a single health check against the claim. If we have failed
+// too many times, this will also start a partition release. Returns true if the
+// partition is healthy, else false.
+func (c *claim) healthCheck() bool {
+	// Get velocities; these functions both use the locks so we have to do this before
+	// we personally take the lock (to avoid deadlock)
+	consumerVelocity := c.ConsumerVelocity()
+	partitionVelocity := c.PartitionVelocity()
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// If our heartbeat is expired, we are definitely unhealthy... don't even bother
+	// with checking velocity
+	nowTime := time.Now().Unix()
+	if c.lastHeartbeat < nowTime-HeartbeatInterval {
+		log.Warningf("%s:%d consumer unhealthy by heartbeat test, releasing",
+			c.topic, c.partID)
+		go func() {
+			c.Release()
+		}()
+		return false
+	}
+
+	// If current has gone forward of the latest (which is possible, but unlikely)
+	// then we are by definition caught up
+	if c.offsetCurrent >= c.offsetLatest {
+		c.cyclesBehind = 0
+		return true
+	}
+
+	// If velocity is good, reset cycles behind and exit
+	if partitionVelocity <= consumerVelocity {
+		c.cyclesBehind = 0
+		return true
+	}
+
+	// Unhealthy, so increase the cycle count so we know when it's been unhealthy for
+	// too long and we want to give it up
+	c.cyclesBehind++
+
+	// If were behind by too many cycles, then we should try to release the
+	// partition. If so, do this in a goroutine since it will involve calling out
+	// to Kafka and releasing the partition.
+	if c.cyclesBehind >= 3 {
+		log.Errorf("%s:%d consumer unhealthy, releasing",
+			c.topic, c.partID)
+		go func() {
+			c.Release()
+		}()
+		return false
+	}
+
+	// Clearly we haven't been behind for long enough, so we're still "healthy"
+	return true
+}
+
+// healthCheckLoop runs regularly and will perform a health check. Exits when we are no longer
+// a claimed partition
+func (c *claim) healthCheckLoop() {
+	for {
+		// We need to health check more often than the heartbeat, but we need to jitter so that
+		// releases don't get synchronized across the fleet.
+		jitter := c.rand.Intn(HeartbeatInterval/2) + (HeartbeatInterval / 2)
+		time.Sleep(time.Duration(jitter) * time.Second)
+
+		// Exit this loop if unclaimed
+		if !c.Claimed() {
+			log.Debugf("%s:%d health check loop exiting", c.topic, c.partID)
+			return
+		}
+
+		c.healthCheck()
+	}
+}
+
+// average returns the average of a given slice of int64s. It ignores 0s as
+// those are "uninitialized" elements.
+func average(vals []int64) float64 {
+	min, max, ct := int64(0), int64(0), int64(0)
+	for _, val := range vals {
+		if val <= 0 {
+			continue
+		}
+		if min == 0 || val < min {
+			min = val
+		}
+		if max == 0 || val > max {
+			max = val
+		}
+		ct++
+	}
+	if ct == 0 {
+		return 0
+	}
+	return float64(max-min) / float64(ct)
+}
+
+// ConsumerVelocity returns the average of our consumers' velocity
+func (c *claim) ConsumerVelocity() float64 {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return average(c.offsetCurrentHistory[0:])
+}
+
+// PartitionVelocity returns the average of the partition's velocity
+func (c *claim) PartitionVelocity() float64 {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return average(c.offsetLatestHistory[0:])
+}
+
+// updateOffsets will update the offsets of our current partition.
+func (c *claim) updateOffsets(ctr int) error {
+	// Slow, hits Kafka. Run in a goroutine.
+	oEarly, oLate, _, err := c.marshal.GetPartitionOffsets(c.topic, c.partID)
+	if err != nil {
+		log.Errorf("%s:%d failed to get offsets: %s", c.topic, c.partID, err)
+		return err
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Update the earliest/latest offsets that are presently available within the
+	// partition
+	c.offsetEarliest = oEarly
+	c.offsetLatest = oLate
+
+	// Do update our "history" values, this is used for calculating moving averages
+	// in the health checking function
+	c.offsetLatestHistory[ctr%10] = oLate
+	c.offsetCurrentHistory[ctr%10] = c.offsetCurrent
+
+	return nil
+}

--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -116,12 +116,13 @@ func newClaim(topic string, partID int, marshal *Marshaler) *claim {
 // state.
 func (c *claim) updateOffsetsLoop() {
 	ctr := 0
+	time.Sleep(<-c.marshal.jitters)
 	for c.Claimed() {
-		time.Sleep(<-c.marshal.jitters)
 		c.updateOffsets(ctr)
 		ctr++
+		time.Sleep(<-c.marshal.jitters)
 	}
-	log.Infof("%s:%d no longer claimed, offset loop exiting", c.topic, c.partID)
+	log.Debugf("%s:%d no longer claimed, offset loop exiting", c.topic, c.partID)
 }
 
 // setup is the initial worker that initializes the claim structure. Until this is done,
@@ -326,11 +327,12 @@ func (c *claim) healthCheck() bool {
 // healthCheckLoop runs regularly and will perform a health check. Exits when we are no longer
 // a claimed partition
 func (c *claim) healthCheckLoop() {
+	time.Sleep(<-c.marshal.jitters)
 	for c.Claimed() {
-		time.Sleep(<-c.marshal.jitters)
 		if c.healthCheck() {
 			go c.heartbeat()
 		}
+		time.Sleep(<-c.marshal.jitters)
 	}
 	log.Debugf("%s:%d health check loop exiting", c.topic, c.partID)
 }

--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -314,6 +314,9 @@ func (c *claim) healthCheck() bool {
 			c.topic, c.partID)
 		go c.Release()
 		return false
+	} else {
+		log.Warningf("%s:%d consumer unhealthy: CV %0.2f < PV %0.2f",
+			c.topic, c.partID, consumerVelocity, partitionVelocity)
 	}
 
 	// Clearly we haven't been behind for long enough, so we're still "healthy"

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -15,12 +15,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/optiopay/kafka"
 	"github.com/optiopay/kafka/proto"
 )
 
 // ConsumerBehavior is the broad category of behaviors that encapsulate how the Consumer
 // will handle claiming/releasing partitions.
+// TODO: Turn this into a consumer options struct.
 type ConsumerBehavior int
 
 const (
@@ -35,100 +35,22 @@ const (
 	CbBalanced = iota
 )
 
-// consumerClaim is our internal tracking structure about a partition.
-type consumerClaim struct {
-	topic         string
-	partID        int
-	claimed       *int32
-	lastHeartbeat int64
-	consumer      kafka.Consumer
-	messages      chan *proto.Message
-
-	// Number of heartbeat cycles this claim has been lagging, i.e., consumption is going
-	// too slowly (defined as being behind by more than 2 heartbeat cycles)
-	cyclesBehind int
-
-	// A Kafka partition consists of N messages with offsets. In the basic case, you
-	// can think of an offset like an array index. With log compaction and other trickery
-	// it acts more like a sparse array, but it's a close enough metaphor.
-	//
-	// We keep track of four values for offsets:
-	//
-	//    offsets       1     2     3     7     9    10    11
-	//   partition  [ msg1, msg2, msg3, msg4, msg5, msg6, msg7, ... ]
-	//                 ^                  ^                      ^
-	//                 \- offsetEarliest  |                      |
-	//                                    \- offsetCurrent   offsetLatest
-	//                                     and startOffset
-	//
-	// In this example, offsetEarliest is 1 which is the "oldest" offset within the
-	// partition. At any given time this offset might become invalid (if a log rolls)
-	// so we might update it. startOffset is simply the value of offsetCurrent at
-	// the very beginning of consumption (for tracking velocity).
-	//
-	// offsetCurrent is 7, which is the offset of the NEXT message i.e. this message
-	// has not been consumed yet.
-	//
-	// offsetLatest is 12, which is the offset that Kafka will assign to the message
-	// that next gets committed to the partition. This offset does not yet exist,
-	// and mit might never.
-	offsetCurrent  int64
-	offsetEarliest int64
-	offsetLatest   int64
-
-	// These track the offset and time of when consumption started. This is going to
-	// be the values from the first Heartbeat message we generate.
-	startOffset int64
-	startTime   int64
-}
-
-// messagePump continuously pulls message from Kafka for this partition and makes them
-// available for consumption.
-func (c *consumerClaim) messagePump() {
-	// This method MUST NOT make changes to the consumerClaim structure. Since we might
-	// be running while someone else has the lock, and we can't get it ourselves, we are
-	// forbidden to touch anything other than the consumer and the message channel.
-	for {
-		if atomic.LoadInt32(c.claimed) != 1 {
-			log.Infof("%s:%d no longer claimed, pump exiting.", c.topic, c.partID)
-			return
-		}
-
-		msg, err := c.consumer.Consume()
-		if err == proto.ErrOffsetOutOfRange {
-			// Fell out of range, presumably because we're handling this too slow, so
-			// let's abandon this consumer
-			log.Errorf("%s:%d error consuming: out of range, abandoning partition",
-				c.topic, c.partID)
-			atomic.StoreInt32(c.claimed, 0)
-			return
-		}
-		if err != nil {
-			log.Errorf("%s:%d error consuming: %s", c.topic, c.partID, err)
-
-			// Often a consumption error is caused by data going away, such as if we're consuming
-			// from the head and Kafka has deleted the data. In that case we need to wait for
-			// the next offset update, so let's not go crazy
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
-		c.messages <- msg
-	}
-}
-
 // Consumer allows you to safely consume data from a given topic in such a way that you
 // don't need to worry about partitions and can safely split the load across as many
 // processes as might be consuming from this topic. However, you should ONLY create one
 // Consumer per topic in your application!
 type Consumer struct {
+	alive      *int32
 	marshal    *Marshaler
 	topic      string
 	partitions int
 	rand       *rand.Rand
-	claims     map[int]*consumerClaim
-	lock       sync.RWMutex
 	behavior   ConsumerBehavior
+
+	// claims maps partition IDs to claim structures. The lock protects read/write
+	// access to this map.
+	claims map[int]*claim
+	lock   sync.RWMutex
 }
 
 // NewConsumer instantiates a consumer object for a given topic. You must create a
@@ -142,35 +64,18 @@ func NewConsumer(marshal *Marshaler, topicName string,
 	}
 
 	consumer := &Consumer{
+		alive:      new(int32),
 		marshal:    marshal,
 		topic:      topicName,
 		partitions: marshal.Partitions(topicName),
 		behavior:   behavior,
 		rand:       rand.New(rand.NewSource(time.Now().UnixNano())),
-		claims:     make(map[int]*consumerClaim),
+		claims:     make(map[int]*claim),
 	}
+	atomic.StoreInt32(consumer.alive, 1)
 	go consumer.manageClaims()
 
 	return consumer, nil
-}
-
-// updateOffsets will update the offsets of any partitions that we claim.
-func (c *Consumer) updateOffsets() error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	for partID, claim := range c.claims {
-		oEarly, oLate, _, err := c.marshal.GetPartitionOffsets(c.topic, partID)
-		if err != nil {
-			log.Errorf("Failed to get offsets for %s:%d: %s", c.topic, partID, err)
-			return err
-		}
-
-		// DO NOT update current, but we can update early/late
-		claim.offsetEarliest = oEarly
-		claim.offsetLatest = oLate
-	}
-	return nil
 }
 
 // tryClaimPartition attempts to claim a partition and make it available in the consumption
@@ -187,81 +92,40 @@ func (c *Consumer) tryClaimPartition(partID int) bool {
 		return false
 	}
 
-	// Get all available offset information
-	oEarly, oLate, oCur, err := c.marshal.GetPartitionOffsets(c.topic, partID)
-	if err != nil {
-		log.Errorf("Failed to get offsets for %s:%d: %s", c.topic, partID, err)
-		return false
-	}
-	log.Debugf("Partition %s:%d offsets: early = %d, cur = %d, late = %d",
-		c.topic, partID, oEarly, oCur, oLate)
-
-	// Set up internal claim structure we'll track things in
-	claim := &consumerClaim{
-		topic:          c.topic,
-		partID:         partID,
-		claimed:        new(int32),
-		offsetEarliest: oEarly,
-		offsetLatest:   oLate,
-		offsetCurrent:  oCur,
-		messages:       make(chan *proto.Message, 100),
-	}
-	atomic.StoreInt32(claim.claimed, 1)
-
-	// Now try to actually claim it, this can block a while
-	log.Infof("Consumer attempting to claim: %s:%d", c.topic, partID)
-	if !c.marshal.ClaimPartition(c.topic, partID) {
-		log.Infof("Consumer failed to claim: %s:%d", c.topic, partID)
+	// Set up internal claim structure we'll track things in, this can block for a while
+	// as it talks to Kafka and waits for rationalizers.
+	newclaim := newClaim(c.topic, partID, c.marshal)
+	if newclaim == nil {
 		return false
 	}
 
-	// Of course, if the current offset is greater than the earliest, we must reset
-	// to the earliest known
-	if claim.offsetCurrent < claim.offsetEarliest {
-		log.Warningf("Consumer fast-forwarding %s:%d: from %d to %d",
-			c.topic, partID, claim.offsetCurrent, claim.offsetEarliest)
-		claim.offsetCurrent = claim.offsetEarliest
-	}
-
-	// Since it's claimed, we now want to heartbeat with the last seen offset
-	err = c.marshal.Heartbeat(c.topic, partID, claim.offsetCurrent)
-	if err != nil {
-		log.Errorf("Consumer failed to heartbeat %s:%d: %s", c.topic, partID, err)
-		return false
-	}
-	claim.lastHeartbeat = time.Now().Unix()
-
-	// Set the starting position so we can calculate velocity later
-	claim.startOffset = claim.offsetCurrent
-	claim.startTime = claim.lastHeartbeat
-
-	// Set up Kafka consumer
-	consumerConf := kafka.NewConsumerConf(c.topic, int32(partID))
-	consumerConf.StartOffset = claim.offsetCurrent
-	kafkaConsumer, err := c.marshal.kafka.Consumer(consumerConf)
-	if err != nil {
-		log.Errorf("Consumer failed to create Kafka Consumer: %s:%d got %s",
-			c.topic, partID, err)
-		// TODO: There is an optimization here where we could release the partition.
-		// As it stands, we're not doing anything,
-		return false
-	}
-	claim.consumer = kafkaConsumer
-
-	// Now start consuming from this partition (as long as we haven't terminated)
-	go claim.messagePump()
-
-	// Totally done, update our internal structures
-	log.Infof("Consumer claimed: %s:%d at offset %d (is %d behind)",
-		c.topic, partID, claim.offsetCurrent, claim.offsetLatest)
-
-	// Finally overwrite our structure pointer (state is committed to ourselves)
+	// Critical section. Engage the lock here, we hold it until we exit.
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	if c.claims != nil {
-		// Can be nil when we're terminating
-		c.claims[partID] = claim
+
+	// Ugh, we managed to claim a partition in our termination state. Don't worry too hard
+	// and just release it.
+	if c.Terminated() {
+		// This can be a long blocking operation so send it to the background. We ultimately
+		// don't care if it finishes or not, because the heartbeat will save us if we don't
+		// submit a release message. This is just an optimization.
+		go func() {
+			newclaim.Release()
+		}()
+		return false
 	}
+
+	// Ensure we don't have another valid claim in this slot. This shouldn't happen and if
+	// it does we treat it as fatal.
+	oldClaim, ok := c.claims[partID]
+	if ok && oldClaim != nil {
+		if oldClaim.Claimed() {
+			log.Fatalf("Internal double-claim for %s:%d.", c.topic, partID)
+		}
+	}
+
+	// Save the claim, this makes it available for message consumption and status.
+	c.claims[partID] = newclaim
 	return true
 }
 
@@ -273,14 +137,12 @@ func (c *Consumer) claimPartitions() {
 	for i := 0; i < c.partitions; i++ {
 		partID := (i + offset) % c.partitions
 
-		// If it's present in the structure, we assert that it's claimed by us
-		c.lock.RLock()
-		if _, ok := c.claims[partID]; ok {
-			c.lock.RUnlock()
+		// Ask the marshaler if it's claimed by anybody
+		if c.marshal.GetPartitionClaim(c.topic, partID).LastHeartbeat > 0 {
 			continue
 		}
-		c.lock.RUnlock()
 
+		// Unclaimed, so attempt to claim it
 		if !c.tryClaimPartition(partID) {
 			continue
 		}
@@ -293,145 +155,44 @@ func (c *Consumer) claimPartitions() {
 	}
 }
 
-func (c *Consumer) getUnhealthyClaims() []*consumerClaim {
-	nowTime := time.Now().Unix()
-
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	var unclaimPartitions []*consumerClaim
-	for _, claim := range c.claims {
-		// If a partition has unmarked itself then it has determined that it is unhealthy,
-		// so we want to unclaim it
-		if atomic.LoadInt32(claim.claimed) == 0 {
-			unclaimPartitions = append(unclaimPartitions, claim)
-			continue
-		}
-
-		// If current has gone forward of the latest (which is possible, but unlikely)
-		// then we are by definition caught up
-		if claim.offsetCurrent >= claim.offsetLatest {
-			continue
-		}
-
-		// And if we've never consumed from the partition, then never let it be considered
-		// unhealthy (by this flow). A partition that is not being consumed from is not
-		// being heartbeated to, so we will lose the lock through that path.
-		if claim.offsetCurrent == claim.startOffset || nowTime == claim.startTime {
-			continue
-		}
-
-		// Calculate the velocity (how fast the consumer is going) and how many seconds
-		// behind we seem to be
-		velocity := float64(claim.offsetCurrent-claim.startOffset) /
-			float64(nowTime-claim.startTime)
-		secondsBehind := float64(claim.offsetLatest-claim.offsetCurrent) / velocity
-
-		// If it's over two intervals, increase the cycles behind counter (we don't want
-		// to oscillate claims too much, and we need to ensure we have enough data to
-		// decide it's unhealthy).
-		if secondsBehind > HeartbeatInterval*2 {
-			claim.cyclesBehind++
-			log.Warningf("Consumer for %s:%d is %0.2f seconds behind, %d cycle(s).",
-				claim.topic, claim.partID, secondsBehind, claim.cyclesBehind)
-
-			// If were behind by too many cycles, then we should try to release the
-			// partition.
-			if claim.cyclesBehind >= 3 {
-				unclaimPartitions = append(unclaimPartitions, claim)
-			}
-		} else {
-			claim.cyclesBehind = 0
-		}
-	}
-
-	return unclaimPartitions
-}
-
 // manageClaims is our internal state machine that handles partitions and claiming new
 // ones (or releasing ones).
 func (c *Consumer) manageClaims() {
-	nextOffsetUpdate := time.Now()
 	for {
-		// See if consumer is alive (hasn't been terminated)
-		c.lock.RLock()
-		if c.claims == nil {
-			c.lock.RUnlock()
+		if c.Terminated() {
 			return
 		}
-		claimCount := len(c.claims)
-		c.lock.RUnlock()
 
-		// Update offsets of all of our claims so we can check how far along they are
-		if time.Now().After(nextOffsetUpdate) {
-			c.updateOffsets()
-			nextOffsetUpdate = time.Now().Add(HeartbeatInterval * time.Second)
-
-			// Get a list of partitions that seem to be unhealthy (too far behind)
-			unclaimPartitions := c.getUnhealthyClaims()
-
-			// If any partitions to unclaim, do it
-			if len(unclaimPartitions) > 0 {
-				// At most, we're only willing to release up to half of our partitions, because we
-				// don't want to end up giving up everything
-				maxToRelease := claimCount / 2
-				log.Warningf("Found %d unhealthy partitions out of %d total.",
-					len(unclaimPartitions), claimCount)
-
-				// Kill the message pumps, unclaim them internally, and delete from the list
-				c.lock.Lock()
-				for _, claim := range unclaimPartitions {
-					if maxToRelease <= 0 {
-						log.Warningf("Too many partitions unhealthy, keeping some.")
-						break
-					}
-					maxToRelease--
-
-					atomic.StoreInt32(claim.claimed, 0)
-					delete(c.claims, claim.partID)
-				}
-				c.lock.Unlock()
-
-				// Now that we're outside of the lock, actually do the slow production of the
-				// release partition messages
-				for _, claim := range unclaimPartitions {
-					log.Warningf("Releasing %s:%d: consumer is unhealthy.",
-						claim.topic, claim.partID)
-					c.marshal.ReleasePartition(claim.topic, claim.partID, claim.offsetCurrent)
-				}
-			}
-		}
-
-		// At this point, we don't need to engage in any load shedding behavior, so let's
-		// see if there are any partitions out there we can claim
+		// Attempt to claim more partitions, this always runs and will keep running until all
+		// partitions in the topic are claimed (by somebody).
 		c.claimPartitions()
 
 		// Now sleep a bit so we don't pound things
-		time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond)
+		// TODO: Raise this later, we shouldn't attempt to claim this fast, this is just for
+		// development.
+		time.Sleep(time.Duration(rand.Intn(3000)) * time.Millisecond)
 	}
+}
+
+// Terminated returns whether or not this consumer has been terminated.
+func (c *Consumer) Terminated() bool {
+	return atomic.LoadInt32(c.alive) == 0
 }
 
 // Terminate instructs the consumer to release its locks. This will allow other consumers
 // to begin consuming. (If you do not call this method before exiting, things will still
 // work, but more slowly.)
 func (c *Consumer) Terminate() {
+	if !atomic.CompareAndSwapInt32(c.alive, 1, 0) {
+		return
+	}
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	for partID, claim := range c.claims {
-		atomic.StoreInt32(claim.claimed, 0) // Terminates the pump.
-		err := c.marshal.ReleasePartition(c.topic, partID, claim.offsetCurrent)
-		if err == nil {
-			log.Infof("Consumer termination: released %s:%d at %d",
-				c.topic, partID, claim.offsetCurrent)
-		} else {
-			log.Errorf("Consumer termination: failed to release %s:%d: %s",
-				c.topic, partID, err)
-		}
+	for _, claim := range c.claims {
+		claim.Release()
 	}
-
-	// Remove the map, so we can't operate anymore
-	c.claims = nil
 }
 
 // GetCurrentLag returns the number of messages that this consumer is lagging by. Note that
@@ -467,6 +228,7 @@ func (c *Consumer) GetCurrentLoad() int {
 func (c *Consumer) Consume() []byte {
 	// TODO: This is almost certainly a slow implementation as we have to scan everything
 	// every time.
+	nextForcedHeartbeat := time.Now().Add(HeartbeatInterval * time.Second)
 	for {
 		var msg *proto.Message
 
@@ -477,12 +239,43 @@ func (c *Consumer) Consume() []byte {
 		for _, claim := range c.claims {
 			select {
 			case msg = <-claim.messages:
-				break
+				// ...
 			default:
 				// Do nothing.
 			}
+			if msg != nil {
+				break
+			}
 		}
 		c.lock.RUnlock()
+
+		// Check for a forced heartbeat cycle where we heartbeat for any idle partitions
+		// that haven't generated a message in a while
+		now := time.Now()
+		if now.After(nextForcedHeartbeat) {
+			nextForcedHeartbeat = now.Add(HeartbeatInterval * time.Second)
+			cutoffTime := now.Unix() - HeartbeatInterval
+			c.lock.Lock()
+			for _, claim := range c.claims {
+				if claim.lastHeartbeat < cutoffTime {
+					claim.lastHeartbeat = now.Unix()
+					go func(claimed *int32, ctopic string, cpartID int, coffset int64) {
+						// Don't use 'claim' here, as this will definitely run outside of the lock
+						log.Infof("Need to heartbeat for %s:%d.", ctopic, cpartID)
+						err := c.marshal.Heartbeat(ctopic, cpartID, coffset)
+						if err != nil {
+							log.Errorf("Failed to heartbeat for %s:%d: %s",
+								ctopic, cpartID, err)
+							atomic.StoreInt32(claimed, 0)
+						}
+					}(claim.claimed, claim.topic, claim.partID, claim.offsetCurrent)
+				} else {
+					log.Debugf("Heartbeat not needed for %s:%d", claim.topic, claim.partID)
+				}
+			}
+			log.Debugf("Claims: %d", len(c.claims))
+			c.lock.Unlock()
+		}
 
 		// TODO: This is braindead.
 		if msg == nil {
@@ -493,14 +286,6 @@ func (c *Consumer) Consume() []byte {
 		// Once we're consuming a message we need to update our data structure as well
 		// as possibly make a heartbeat for this partition so the world knows we're
 		// still actively consuming
-		// TODO: There is a trap here, this is actually probably a bad design in that
-		// the consumer has its own idea of "claim" which in theory mirrors what the
-		// marshaler has... but there's no guarantee
-		// Of course for the ALO consumer, that's probably OK. It's just a bad code design
-		// I think.
-		// Actually it might not be that bad. Only the consumer knows when it has decided
-		// it has fallen too far behind and released a partition.
-
 		c.lock.Lock()
 		claim, ok := c.claims[int(msg.Partition)]
 		if !ok {
@@ -517,11 +302,16 @@ func (c *Consumer) Consume() []byte {
 			if claim.lastHeartbeat <= (now - HeartbeatInterval) {
 				claim.lastHeartbeat = now
 				// Do this in a goroutine so as not to block the consumption
-				go func() {
+				go func(claimed *int32) {
 					// Don't use 'claim' here, as this will definitely run outside of the lock
-					log.Debugf("Need to heartbeat for %s:%d.", msg.Topic, msg.Partition)
-					c.marshal.Heartbeat(msg.Topic, int(msg.Partition), msg.Offset)
-				}()
+					log.Infof("Need to heartbeat for %s:%d.", msg.Topic, msg.Partition)
+					err := c.marshal.Heartbeat(msg.Topic, int(msg.Partition), msg.Offset)
+					if err != nil {
+						log.Errorf("Failed to heartbeat for %s:%d: %s",
+							msg.Topic, msg.Partition, err)
+						atomic.StoreInt32(claimed, 0)
+					}
+				}(claim.claimed)
 			}
 			c.lock.Unlock()
 			return msg.Value

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -167,11 +167,7 @@ func (c *Consumer) claimPartitions() {
 // manageClaims is our internal state machine that handles partitions and claiming new
 // ones (or releasing ones).
 func (c *Consumer) manageClaims() {
-	for {
-		if c.Terminated() {
-			return
-		}
-
+	for !c.Terminated() {
 		// Attempt to claim more partitions, this always runs and will keep running until all
 		// partitions in the topic are claimed (by somebody).
 		c.claimPartitions()
@@ -200,7 +196,9 @@ func (c *Consumer) Terminate() {
 	defer c.lock.Unlock()
 
 	for _, claim := range c.claims {
-		claim.Release()
+		if claim != nil {
+			claim.Release()
+		}
 	}
 }
 

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -2,6 +2,8 @@ package marshal
 
 import (
 	"math/rand"
+	"strconv"
+	"sync/atomic"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -28,13 +30,15 @@ func (s *ConsumerSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.cn = &Consumer{
+		alive:      new(int32),
 		marshal:    s.m,
 		topic:      "test16",
 		partitions: s.m.Partitions("test16"),
 		behavior:   CbAggressive,
 		rand:       rand.New(rand.NewSource(time.Now().UnixNano())),
-		claims:     make(map[int]*consumerClaim),
+		claims:     make(map[int]*claim),
 	}
+	atomic.StoreInt32(s.cn.alive, 1)
 }
 
 func (s *ConsumerSuite) Produce(topicName string, partID int, msgs ...string) int64 {
@@ -68,44 +72,76 @@ func (s *ConsumerSuite) TestNewConsumer(c *C) {
 	// lots of things can be tested.
 }
 
-func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
-	// Claim partition 0, update our offsets, produce, update offsets again, ensure everything
-	// is consistent (offsets got updated, etc)
+func (s *ConsumerSuite) TestMultiClaim(c *C) {
+	// Set up claims on two partitions, we'll put messages in both and then ensure that
+	// we get all of the messages out
 	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
 	c.Assert(s.cn.tryClaimPartition(1), Equals, true)
 
+	// Produce 1000 messages to the two partitions
+	for i := 0; i < 1000; i++ {
+		s.Produce("test16", i%2, strconv.Itoa(i))
+	}
+
+	// Now consume 1000 times and ensure we get exactly 1000 unique messages
+	results := make(map[string]bool)
+	for i := 0; i < 1000; i++ {
+		results[string(s.cn.Consume())] = true
+	}
+	c.Assert(len(results), Equals, 1000)
+}
+
+func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
+	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
+	cl := s.cn.claims[0]
+
 	// We just claimed, nothing should be unhealthy
-	c.Assert(len(s.cn.getUnhealthyClaims()), Equals, 0)
+	c.Assert(cl.healthCheck(), Equals, true)
+	c.Assert(cl.cyclesBehind, Equals, 0)
 
-	// Now put some messages in and update offsets, then we will still be "healthy" since we
-	// haven't consumed
-	s.Produce("test16", 0, "m1", "m2", "m3")
-	c.Assert(s.cn.updateOffsets(), IsNil)
-	c.Assert(len(s.cn.getUnhealthyClaims()), Equals, 0)
-
-	// Now consume some messages, and we'll still be healthy
+	// Put in one message and consume it making sure things work, and then update offsets.
+	s.Produce("test16", 0, "m1")
 	c.Assert(s.cn.Consume(), DeepEquals, []byte("m1"))
-	c.Assert(len(s.cn.getUnhealthyClaims()), Equals, 0)
+	c.Assert(cl.updateOffsets(0), IsNil)
+	c.Assert(cl.healthCheck(), Equals, true)
+	c.Assert(cl.cyclesBehind, Equals, 0)
 
-	// Update the claim structure so it looks like it's behind, but it's not yet in the danger
-	// of being released
-	s.cn.claims[0].startTime -= HeartbeatInterval * 2
-	c.Assert(len(s.cn.getUnhealthyClaims()), Equals, 0)
-	c.Assert(s.cn.claims[0].cyclesBehind, Equals, 1)
-
-	// A second call will increase the cycles behind again, but still not release
-	c.Assert(len(s.cn.getUnhealthyClaims()), Equals, 0)
-	c.Assert(s.cn.claims[0].cyclesBehind, Equals, 2)
-
-	// And a third call, this time the partition shows up in our list
-	c.Assert(len(s.cn.getUnhealthyClaims()), Equals, 1)
-	c.Assert(s.cn.claims[0].cyclesBehind, Equals, 3)
-
-	// Now let's consume a second message and double our velocity, which will take us under
-	// the threshold and reset our behind count
+	// Produce 5, consume 3... at this point we are "unhealthy" since we are falling
+	// behind for this period
+	s.Produce("test16", 0, "m2", "m3", "m4", "m5", "m6")
 	c.Assert(s.cn.Consume(), DeepEquals, []byte("m2"))
-	c.Assert(len(s.cn.getUnhealthyClaims()), Equals, 0)
-	c.Assert(s.cn.claims[0].cyclesBehind, Equals, 0)
+	c.Assert(s.cn.Consume(), DeepEquals, []byte("m3"))
+	c.Assert(s.cn.Consume(), DeepEquals, []byte("m4"))
+	c.Assert(cl.updateOffsets(1), IsNil)
+	c.Assert(cl.healthCheck(), Equals, true)
+	c.Assert(cl.cyclesBehind, Equals, 1)
+
+	// Produce nothing and consume the last two, we become healthy again because
+	// we are caught up and our velocity is equal
+	c.Assert(s.cn.Consume(), DeepEquals, []byte("m5"))
+	c.Assert(s.cn.Consume(), DeepEquals, []byte("m6"))
+	c.Assert(cl.updateOffsets(2), IsNil)
+	c.Assert(cl.healthCheck(), Equals, true)
+	c.Assert(cl.ConsumerVelocity() == cl.PartitionVelocity(), Equals, true)
+	c.Assert(cl.cyclesBehind, Equals, 0)
+
+	// Produce again, falls behind slightly
+	s.Produce("test16", 0, "m7")
+	c.Assert(cl.updateOffsets(3), IsNil)
+	c.Assert(cl.healthCheck(), Equals, true)
+	c.Assert(cl.cyclesBehind, Equals, 1)
+
+	// Still behind
+	c.Assert(cl.updateOffsets(4), IsNil)
+	c.Assert(cl.healthCheck(), Equals, true)
+	c.Assert(cl.cyclesBehind, Equals, 2)
+
+	// Consume the last message, which will fix our velocity and let us
+	// pass as healthy again
+	c.Assert(s.cn.Consume(), DeepEquals, []byte("m7"))
+	c.Assert(cl.updateOffsets(5), IsNil)
+	c.Assert(cl.healthCheck(), Equals, true)
+	c.Assert(cl.cyclesBehind, Equals, 0)
 }
 
 func (s *ConsumerSuite) TestConsumerHeartbeat(c *C) {
@@ -142,9 +178,9 @@ func (s *ConsumerSuite) TestOffsetUpdates(c *C) {
 	// Claim partition 0, update our offsets, produce, update offsets again, ensure everything
 	// is consistent (offsets got updated, etc)
 	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
-	c.Assert(s.cn.updateOffsets(), IsNil)
+	c.Assert(s.cn.claims[0].updateOffsets(0), IsNil)
 	c.Assert(s.Produce("test16", 0, "m1", "m2", "m3"), Equals, int64(2))
-	c.Assert(s.cn.updateOffsets(), IsNil)
+	c.Assert(s.cn.claims[0].updateOffsets(1), IsNil)
 	c.Assert(s.cn.claims[0].offsetLatest, Equals, int64(3))
 }
 

--- a/marshal/world.go
+++ b/marshal/world.go
@@ -26,9 +26,10 @@ type Marshaler struct {
 	clientID string
 	groupID  string
 
-	lock   sync.RWMutex
-	topics map[string]int
-	groups map[string]map[string]*topicState
+	lock    sync.RWMutex
+	topics  map[string]int
+	groups  map[string]map[string]*topicState
+	jitters chan time.Duration
 
 	rationalizers sync.WaitGroup
 


### PR DESCRIPTION
The locking was getting crazy and hard to use, and the logic in the
Consumer was getting unwieldy. This breaks the individual per-partition
claim logic down into a "claim" type which can self-manage.

There is still some work to do, but this is at least a start.
