### PR TITLE
Add fast-reclaim

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -273,6 +273,8 @@ func (c *claim) heartbeat() bool {
 		return false
 	}
 
+	// TODO: This holds a lock around a Kafka transaction do we really want that?
+	// Won't this block consumption pretty hard?
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/marshal/marshal_test.go
+++ b/marshal/marshal_test.go
@@ -41,6 +41,7 @@ func StartServer() *kafkatest.Server {
 	srv.MustSpawn()
 	MakeTopic(srv, MarshalTopic, 4)
 	MakeTopic(srv, "test1", 1)
+	MakeTopic(srv, "test2", 2)
 	MakeTopic(srv, "test16", 16)
 	return srv
 }


### PR DESCRIPTION
This makes fast reclamation mode work. This is simply "does anybody with
my client/group have this partition, if so, that was me so reclaim it".
There is still some protection we can add to prevent operator errors
that should be added.

Fixes #10.
