### PR TITLE
Implement partition usage

### DIFF
--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -18,9 +18,7 @@ import (
 	"github.com/optiopay/kafka/proto"
 )
 
-// ConsumerBehavior is the broad category of behaviors that encapsulate how the Consumer
-// will handle claiming/releasing partitions.
-// TODO: Turn this into a consumer options struct.
+// ConsumerOptions represents all of the options that a consumer can be configured with.
 type ConsumerOptions struct {
 	// FastReclaim instructs the consumer to attempt to reclaim any partitions
 	// that are presently claimed by the ClientID/GroupID we have. This is useful

--- a/marshal/marshal_test.go
+++ b/marshal/marshal_test.go
@@ -47,10 +47,20 @@ func StartServer() *kafkatest.Server {
 }
 
 func (s *MarshalSuite) TestNewMarshaler(c *C) {
+	// Test that Marshaler starts up and learns about the topics.
 	c.Assert(s.m.Partitions(MarshalTopic), Equals, 4)
 	c.Assert(s.m.Partitions("test1"), Equals, 1)
+	c.Assert(s.m.Partitions("test2"), Equals, 2)
 	c.Assert(s.m.Partitions("test16"), Equals, 16)
 	c.Assert(s.m.Partitions("unknown"), Equals, 0)
+
+	// If our hash algorithm changes, these values will have to change. This tests the low
+	// level hash function.
+	c.Assert(s.m.getClaimPartition("test1"), Equals, 2)
+	c.Assert(s.m.getClaimPartition("test2"), Equals, 1)
+	c.Assert(s.m.getClaimPartition("test16"), Equals, 0)
+	c.Assert(s.m.getClaimPartition("unknown"), Equals, 1)
+	c.Assert(s.m.getClaimPartition("unknown"), Equals, 1) // Twice on purpose.
 }
 
 // This is a full integration test of claiming including writing to Kafka via the marshaler

--- a/marshal/rationalizer.go
+++ b/marshal/rationalizer.go
@@ -24,11 +24,11 @@ func (w *Marshaler) kafkaConsumerChannel(partID int) <-chan message {
 		// Figure out how many messages are in this topic
 		offsetFirst, err := w.kafka.OffsetEarliest(MarshalTopic, int32(partID))
 		if err != nil {
-			log.Fatalf("rationalize[%d]: Failed to get offset: %s", err)
+			log.Fatalf("rationalize[%d]: failed to get offset: %s", partID, err)
 		}
 		offsetNext, err := w.kafka.OffsetLatest(MarshalTopic, int32(partID))
 		if err != nil {
-			log.Fatalf("rationalize[%d]: Failed to get offset: %s", err)
+			log.Fatalf("rationalize[%d]: failed to get offset: %s", partID, err)
 		}
 		log.Debugf("rationalize[%d]: offsets %d to %d", partID, offsetFirst, offsetNext)
 
@@ -82,7 +82,7 @@ func (w *Marshaler) kafkaConsumerChannel(partID int) <-chan message {
 				continue
 			}
 
-			log.Debugf("Got message at offset %d: [%s]", msgb.Offset, msg.Encode())
+			log.Errorf("rationalize[%d]: @%d: [%s]", partID, msgb.Offset, msg.Encode())
 			out <- msg
 
 			// This is a one-time thing that fires the first time the rationalizer comes up

--- a/marshal/rationalizer.go
+++ b/marshal/rationalizer.go
@@ -82,7 +82,7 @@ func (w *Marshaler) kafkaConsumerChannel(partID int) <-chan message {
 				continue
 			}
 
-			log.Errorf("rationalize[%d]: @%d: [%s]", partID, msgb.Offset, msg.Encode())
+			log.Debugf("rationalize[%d]: @%d: [%s]", partID, msgb.Offset, msg.Encode())
 			out <- msg
 
 			// This is a one-time thing that fires the first time the rationalizer comes up

--- a/marshal/rationalizer_test.go
+++ b/marshal/rationalizer_test.go
@@ -46,11 +46,12 @@ func (s *RationalizerSuite) TearDownTest(c *C) {
 
 func NewWorld() *Marshaler {
 	return &Marshaler{
-		quit:     new(int32),
-		rsteps:   new(int32),
-		clientID: "cl",
-		groupID:  "gr",
-		groups:   make(map[string]map[string]*topicState),
+		quit:       new(int32),
+		rsteps:     new(int32),
+		clientID:   "cl",
+		groupID:    "gr",
+		groups:     make(map[string]map[string]*topicState),
+		partitions: 1,
 	}
 }
 

--- a/marshal/topic.go
+++ b/marshal/topic.go
@@ -15,7 +15,11 @@ import (
 
 // topicState contains information about a given topic.
 type topicState struct {
-	// This lock also protects the contenst of the partitions.
+	// claimPartition is which Marshal topic partition to use for coordination of this topic.
+	// Read only, set at initialization time so not protected by the lock.
+	claimPartition int
+
+	// This lock also protects the contents of the partitions member.
 	lock       sync.RWMutex
 	partitions []PartitionClaim
 }


### PR DESCRIPTION
This adds topic hashing for Marshaler so it can spread load across the
coordination topic partitions.

Fixes #7.
