### PR TITLE
Add committed offset usage

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -30,6 +30,7 @@ type claim struct {
 	// lock protects all access to the member variables of this struct except for the
 	// messages channel, which can be read from or written to without holding the lock.
 	lock          sync.RWMutex
+	offsets       PartitionOffsets
 	marshal       *Marshaler
 	rand          *rand.Rand
 	claimed       *int32
@@ -41,35 +42,7 @@ type claim struct {
 	// too slowly (defined as being behind by more than 2 heartbeat cycles)
 	cyclesBehind int
 
-	// A Kafka partition consists of N messages with offsets. In the basic case, you
-	// can think of an offset like an array index. With log compaction and other trickery
-	// it acts more like a sparse array, but it's a close enough metaphor.
-	//
-	// We keep track of four values for offsets:
-	//
-	//    offsets       1     2     3     7     9    10    11
-	//   partition  [ msg1, msg2, msg3, msg4, msg5, msg6, msg7, ... ]
-	//                 ^                  ^                      ^
-	//                 \- offsetEarliest  |                      |
-	//                                    \- offsetCurrent   offsetLatest
-	//                                     and startOffset
-	//
-	// In this example, offsetEarliest is 1 which is the "oldest" offset within the
-	// partition. At any given time this offset might become invalid (if a log rolls)
-	// so we might update it. startOffset is simply the value of offsetCurrent at
-	// the very beginning of consumption (for tracking velocity).
-	//
-	// offsetCurrent is 7, which is the offset of the NEXT message i.e. this message
-	// has not been consumed yet.
-	//
-	// offsetLatest is 12, which is the offset that Kafka will assign to the message
-	// that next gets committed to the partition. This offset does not yet exist,
-	// and might never.
-	offsetCurrent  int64
-	offsetEarliest int64
-	offsetLatest   int64
-
-	// History arrays used for calculating average veolocity for health checking.
+	// History arrays used for calculating average velocity for health checking.
 	offsetCurrentHistory [10]int64
 	offsetLatestHistory  [10]int64
 }
@@ -78,41 +51,39 @@ type claim struct {
 // claim of a single partition.
 func newClaim(topic string, partID int, marshal *Marshaler) *claim {
 	// Get all available offset information
-	oEarly, oLate, oCur, oComm, err := marshal.GetPartitionOffsets(topic, partID)
+	offsets, err := marshal.GetPartitionOffsets(topic, partID)
 	if err != nil {
 		log.Errorf("%s:%d failed to get offsets: %s", topic, partID, err)
 		return nil
 	}
 	log.Debugf("%s:%d consumer offsets: early = %d, cur/comm = %d/%d, late = %d",
-		topic, partID, oEarly, oCur, oComm, oLate)
+		topic, partID, offsets.Earliest, offsets.Current, offsets.Committed, offsets.Latest)
 
 	// Take the greatest of the committed/current offset, this means we will recover from
 	// a situation where the last time this partition was claimed has fallen out of our
 	// coordination memory.
-	if oComm > 0 && oComm > oCur {
-		if oCur > 0 {
+	if offsets.Committed > 0 && offsets.Committed > offsets.Current {
+		if offsets.Current > 0 {
 			// This state shouldn't really happen. This implies that someone went back in time
 			// and started consuming earlier than the committed offset.
 			log.Warningf("%s:%d committed offset is %d but heartbeat offset was %d",
-				topic, partID, oComm, oCur)
+				topic, partID, offsets.Committed, offsets.Current)
 		} else {
 			log.Infof("%s:%d recovering committed offset of %d",
-				topic, partID, oComm)
+				topic, partID, offsets.Committed)
 		}
-		oCur = oComm
+		offsets.Current = offsets.Committed
 	}
 
 	// Construct object and set it up
 	obj := &claim{
-		marshal:        marshal,
-		topic:          topic,
-		partID:         partID,
-		claimed:        new(int32),
-		offsetEarliest: oEarly,
-		offsetLatest:   oLate,
-		offsetCurrent:  oCur,
-		messages:       make(chan *proto.Message, 100),
-		rand:           rand.New(rand.NewSource(time.Now().UnixNano())),
+		marshal:  marshal,
+		topic:    topic,
+		partID:   partID,
+		claimed:  new(int32),
+		offsets:  offsets,
+		messages: make(chan *proto.Message, 100),
+		rand:     rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 	atomic.StoreInt32(obj.claimed, 1)
 
@@ -149,14 +120,14 @@ func (c *claim) setup() {
 
 	// Of course, if the current offset is greater than the earliest, we must reset
 	// to the earliest known
-	if c.offsetCurrent < c.offsetEarliest {
+	if c.offsets.Current < c.offsets.Earliest {
 		log.Warningf("%s:%d consumer fast-forwarding from %d to %d",
-			c.topic, c.partID, c.offsetCurrent, c.offsetEarliest)
-		c.offsetCurrent = c.offsetEarliest
+			c.topic, c.partID, c.offsets.Current, c.offsets.Earliest)
+		c.offsets.Current = c.offsets.Earliest
 	}
 
 	// Since it's claimed, we now want to heartbeat with the last seen offset
-	err := c.marshal.Heartbeat(c.topic, c.partID, c.offsetCurrent)
+	err := c.marshal.Heartbeat(c.topic, c.partID, c.offsets.Current)
 	if err != nil {
 		log.Errorf("%s:%d consumer failed to heartbeat: %s", c.topic, c.partID, err)
 		atomic.StoreInt32(c.claimed, 0)
@@ -166,7 +137,7 @@ func (c *claim) setup() {
 
 	// Set up Kafka consumer
 	consumerConf := kafka.NewConsumerConf(c.topic, int32(c.partID))
-	consumerConf.StartOffset = c.offsetCurrent
+	consumerConf.StartOffset = c.offsets.Current
 	kafkaConsumer, err := c.marshal.kafka.Consumer(consumerConf)
 	if err != nil {
 		log.Errorf("%s:%d consumer failed to create Kafka Consumer: %s",
@@ -185,7 +156,7 @@ func (c *claim) setup() {
 
 	// Totally done, let the world know and move on
 	log.Infof("%s:%d consumer claimed at offset %d (is %d behind)",
-		c.topic, c.partID, c.offsetCurrent, c.offsetLatest-c.offsetCurrent)
+		c.topic, c.partID, c.offsets.Current, c.offsets.Latest-c.offsets.Current)
 }
 
 // Given a message offset (which should be our current offset), return whether or
@@ -208,7 +179,7 @@ func (c *claim) Consumed(offset int64) bool {
 		return false
 	}
 
-	c.offsetCurrent = offset + 1
+	c.offsets.Current = offset + 1
 	return true
 }
 
@@ -223,8 +194,8 @@ func (c *claim) GetCurrentLag() int64 {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	if c.offsetCurrent < c.offsetLatest {
-		return c.offsetLatest - c.offsetCurrent
+	if c.offsets.Current < c.offsets.Latest {
+		return c.offsets.Latest - c.offsets.Current
 	}
 	return 0
 }
@@ -241,7 +212,7 @@ func (c *claim) Release() bool {
 	defer c.lock.RUnlock()
 
 	log.Infof("%s:%d releasing partition claim", c.topic, c.partID)
-	err := c.marshal.ReleasePartition(c.topic, c.partID, c.offsetCurrent)
+	err := c.marshal.ReleasePartition(c.topic, c.partID, c.offsets.Current)
 	if err != nil {
 		log.Errorf("%s:%d failed to release: %s", c.topic, c.partID, err)
 		return false
@@ -294,7 +265,7 @@ func (c *claim) heartbeat() bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	err := c.marshal.Heartbeat(c.topic, c.partID, c.offsetCurrent)
+	err := c.marshal.Heartbeat(c.topic, c.partID, c.offsets.Current)
 	if err != nil {
 		log.Errorf("%s:%d failed to heartbeat, releasing", c.topic, c.partID)
 		go c.Release()
@@ -331,7 +302,7 @@ func (c *claim) healthCheck() bool {
 
 	// If current has gone forward of the latest (which is possible, but unlikely)
 	// then we are by definition caught up
-	if c.offsetCurrent >= c.offsetLatest {
+	if c.offsets.Current >= c.offsets.Latest {
 		c.cyclesBehind = 0
 		return true
 	}
@@ -416,7 +387,7 @@ func (c *claim) PartitionVelocity() float64 {
 // updateOffsets will update the offsets of our current partition.
 func (c *claim) updateOffsets(ctr int) error {
 	// Slow, hits Kafka. Run in a goroutine.
-	oEarly, oLate, _, _, err := c.marshal.GetPartitionOffsets(c.topic, c.partID)
+	offsets, err := c.marshal.GetPartitionOffsets(c.topic, c.partID)
 	if err != nil {
 		log.Errorf("%s:%d failed to get offsets: %s", c.topic, c.partID, err)
 		return err
@@ -427,13 +398,13 @@ func (c *claim) updateOffsets(ctr int) error {
 
 	// Update the earliest/latest offsets that are presently available within the
 	// partition
-	c.offsetEarliest = oEarly
-	c.offsetLatest = oLate
+	c.offsets.Earliest = offsets.Earliest
+	c.offsets.Latest = offsets.Latest
 
 	// Do update our "history" values, this is used for calculating moving averages
 	// in the health checking function
-	c.offsetLatestHistory[ctr%10] = oLate
-	c.offsetCurrentHistory[ctr%10] = c.offsetCurrent
+	c.offsetLatestHistory[ctr%10] = offsets.Latest
+	c.offsetCurrentHistory[ctr%10] = c.offsets.Current
 
 	return nil
 }

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -186,7 +186,7 @@ func (s *ConsumerSuite) TestCommittedOffset(c *C) {
 	c.Assert(s.m.offsets.Commit("test16", 0, 2), IsNil)
 	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
 	c.Assert(s.m.waitForRsteps(1), Equals, 1)
-	c.Assert(s.cn.claims[0].offsetCurrent, Equals, int64(2))
+	c.Assert(s.cn.claims[0].offsets.Current, Equals, int64(2))
 
 	// Since the committed offset was 2, the first consumption should be the third message
 	c.Assert(s.cn.Consume(), DeepEquals, []byte("m3"))
@@ -211,7 +211,7 @@ func (s *ConsumerSuite) TestCommittedOffset(c *C) {
 	c.Assert(offset, Equals, int64(2))
 	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
 	c.Assert(s.m.waitForRsteps(5), Equals, 5)
-	c.Assert(s.cn.claims[0].offsetCurrent, Equals, int64(3))
+	c.Assert(s.cn.claims[0].offsets.Current, Equals, int64(3))
 }
 
 func (s *ConsumerSuite) TestTryClaimPartition(c *C) {
@@ -272,8 +272,8 @@ func (s *ConsumerSuite) TestFastReclaim(c *C) {
 	// and no claim message sent
 	c.Assert(s.m.waitForRsteps(7), Equals, 7)
 	c.Assert(len(cn.claims), Equals, 2)
-	c.Assert(cn.claims[0].offsetCurrent, Equals, int64(2))
-	c.Assert(cn.claims[1].offsetCurrent, Equals, int64(0))
+	c.Assert(cn.claims[0].offsets.Current, Equals, int64(2))
+	c.Assert(cn.claims[1].offsets.Current, Equals, int64(0))
 
 	// There should be four messages left, but they can come in any order depending
 	// on how things get scheduled. Let's get them all and sort and verify. This


### PR DESCRIPTION
Given the Marshal coordination topic's retention time might be set
fairly short (and should be, in general), we run the risk of offset
memory disappearing if a consumer is down for longer than the retention
period. This is suboptimal.

This implements usage of Kafka's offset coordinator interface to enable
us to store and retrieve offsets. The implemented behavior will take the
max of any offset retrieved from the coordination topic or Kafka.

Fixes #6.
