### PR TITLE
Fix committed offsets

### DIFF
--- a/marshal/world.go
+++ b/marshal/world.go
@@ -216,7 +216,11 @@ func (m *Marshaler) GetPartitionOffsets(topicName string, partID int) (Partition
 
 	o.Committed, _, err = m.offsets.Offset(topicName, int32(partID))
 	if err != nil {
-		return PartitionOffsets{}, err
+		// This error happens when Kafka does not know about the partition i.e. no
+		// offset has been committed here. In that case we ignore it.
+		if err != proto.ErrUnknownTopicOrPartition {
+			return PartitionOffsets{}, fmt.Errorf("offset fetch fail: %s", err)
+		}
 	}
 
 	// Use the last claim we know about, whatever it is


### PR DESCRIPTION
If you don't have an offset in Kafka, it returns 'unknown topic or
partition'. In that case, just treat it as a 0 -- that consumer group
has never recorded an offset for that topic/partition before.
