### PR TITLE
Add real at-least-once

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,12 @@ func main() {
     consumer, _ := marshal.NewConsumer(marshaler, "some-topic", marshal.CbAggressive)
     defer consumer.Terminate()
 
+    msgChan := consumer.ConsumeChannel()
+
     for {
-        fmt.Printf("Consumed message: %s", consumer.Consume())
+        msg := <-msgChan
+        fmt.Printf("Consumed message: %s", msg.Value)
+        consumer.Commit(msg)
     }
 }
 ```

--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -306,13 +306,10 @@ func (c *claim) heartbeat() bool {
 
 	// If we end up with more than 10000 outstanding messages, then something is
 	// probably broken in the implementation... since that will cause us to grow
-	// forever in memory, let's abandon ship
-	if len(c.tracking) > 1000 {
-		log.Warningf("%s:%d has %d uncommitted offsets; are you calling Commit?",
-			c.topic, c.partID, len(offsets))
-	} else if len(c.tracking) > 10000 {
-		log.Fatalf("%s:%d had %d uncommitted offsets. You must call Commit.",
-			c.topic, c.partID, len(offsets))
+	// forever in memory, let's alert the user
+	if len(c.tracking) > 10000 {
+		log.Errorf("%s:%d has %d uncommitted offsets. You must call Commit.",
+			c.topic, c.partID, len(c.tracking))
 	}
 
 	// Now heartbeat this value and update our heartbeat time

--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -77,7 +77,9 @@ func (s *ClaimSuite) TestCommit(c *C) {
 
 	// Consume 1, heartbeat... offsets still 0
 	msg1 := s.consumeOne(c)
+	s.cl.lock.RLock()
 	c.Assert(len(s.cl.tracking), Equals, 6)
+	s.cl.lock.RUnlock()
 	c.Assert(msg1.Value, DeepEquals, []byte("m1"))
 	c.Assert(s.cl.heartbeat(), Equals, true)
 	c.Assert(s.cl.offsets.Current, Equals, int64(0))

--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -133,6 +133,22 @@ func (s *ClaimSuite) TestCommit(c *C) {
 	c.Assert(len(s.cl.tracking), Equals, 0)
 }
 
+func (s *ClaimSuite) BenchmarkConsumeAndCommit(c *C) {
+	// Produce N messages for consumption into the test partition and hopefully this
+	// doesn't end up being the really slow part of the operation
+	msgs := make([]string, 0, c.N)
+	for i := 0; i < c.N; i++ {
+		msgs = append(msgs, "message")
+	}
+	s.Produce("test16", 0, msgs...)
+
+	// Now consume everything and immediately commit it
+	for i := 0; i < c.N; i++ {
+		msg := s.consumeOne(c)
+		s.cl.Commit(msg)
+	}
+}
+
 func (s *ClaimSuite) TestRelease(c *C) {
 	// Test that calling Release on a claim properly sets the flag and releases the
 	// partition


### PR DESCRIPTION
This refactors the way we handle consumption to be channel based. The
client requests a channel from the Consumer, and all claim objects will
write to that channel.

Messages that go into the channel were obtained in a valid manner (i.e.,
but an unexpired claim), but we do not consider them to be "finished"
until the client calls Commit and passes the message back to us.

Once Commit is called, we update the internal state and allow the
heartbeat to move the current offset forward.

Fixes #18.
