### PR TITLE
Add strict ordering

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -206,7 +206,7 @@ func (c *claim) Commit(msg *proto.Message) error {
 	// advise it that it's ready to continue with its life
 	if c.options.StrictOrdering {
 		if c.outstandingMessages == 0 {
-			c.outstandingMessageWait.Signal()
+			defer c.outstandingMessageWait.Signal()
 		}
 	}
 	return nil


### PR DESCRIPTION
Defaulting to off, this adds a consumer option that, when enabled,
forces us to provide strict ordering. Within a single partition (claim)
we will only return a single message. Once that message is committed,
then we can return the second message, etc.

Messages in separate partitions can be returned in parallel, providing
for some throughput concurrency.

Fixes #20.
