### PR TITLE
Fix getTopicState

### DIFF
--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -70,7 +70,7 @@ func (m *Marshaler) NewConsumer(topicName string, options ConsumerOptions) (*Con
 		topic:      topicName,
 		partitions: m.Partitions(topicName),
 		options:    options,
-		messages:   make(chan *proto.Message, 1000),
+		messages:   make(chan *proto.Message, 10000),
 		rand:       rand.New(rand.NewSource(time.Now().UnixNano())),
 		claims:     make(map[int]*claim),
 	}

--- a/marshal/rationalizer.go
+++ b/marshal/rationalizer.go
@@ -119,7 +119,7 @@ func (w *Marshaler) kafkaConsumerChannel(partID int) <-chan message {
 
 // updateClaim is called whenever we need to adjust a claim structure.
 func (w *Marshaler) updateClaim(msg *msgHeartbeat) {
-	topic := w.getTopicState(msg.Topic, msg.PartID)
+	topic := w.getTopicState(msg.GroupID, msg.Topic, msg.PartID)
 
 	topic.lock.Lock()
 	defer topic.lock.Unlock()
@@ -135,7 +135,7 @@ func (w *Marshaler) updateClaim(msg *msgHeartbeat) {
 
 // releaseClaim is called whenever someone has released their claim on a partition.
 func (w *Marshaler) releaseClaim(msg *msgReleasingPartition) {
-	topic := w.getTopicState(msg.Topic, msg.PartID)
+	topic := w.getTopicState(msg.GroupID, msg.Topic, msg.PartID)
 
 	topic.lock.Lock()
 	defer topic.lock.Unlock()
@@ -155,7 +155,7 @@ func (w *Marshaler) releaseClaim(msg *msgReleasingPartition) {
 
 // handleClaim is called whenever we see a ClaimPartition message.
 func (w *Marshaler) handleClaim(msg *msgClaimingPartition) {
-	topic := w.getTopicState(msg.Topic, msg.PartID)
+	topic := w.getTopicState(msg.GroupID, msg.Topic, msg.PartID)
 
 	topic.lock.Lock()
 	defer topic.lock.Unlock()


### PR DESCRIPTION
This method is used by everybody to get the state object to update
within the rationalizer. The problem was that it didn't consider the
groupID and always used Marshal's current GroupID. This meant that, for
all running Marshal clients, they shared the same GroupID in practice.

This is obviously very bad.

This fixes the method to actually properly use GroupID to maintain state
and adds a test to ensure that claims by other users don't affect our
own state.
