### PR TITLE
Average will return NaN when there is only one element in the velocity array

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -382,7 +382,7 @@ func (c *claim) healthCheck() bool {
 
 	// If velocity is good, reset cycles behind and exit
 	if partitionVelocity <= consumerVelocity {
-		if(c.cyclesBehind != 0) {
+		if c.cyclesBehind != 0 {
 			log.Warningf("%s:%d  catching up: (resetting warning) CV %0.2f < PV %0.2f (warning #%d)",
 				c.topic, c.partID, consumerVelocity, partitionVelocity, c.cyclesBehind)
 		}
@@ -397,7 +397,7 @@ func (c *claim) healthCheck() bool {
 	// If were behind by too many cycles, then we should try to release the
 	// partition. If so, do this in a goroutine since it will involve calling out
 	// to Kafka and releasing the partition.
-	if c.cyclesBehind >= 5 {
+	if c.cyclesBehind >= 3 {
 		log.Warningf("%s:%d consumer unhealthy, releasing",
 			c.topic, c.partID)
 		go c.Release()

--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -382,6 +382,10 @@ func (c *claim) healthCheck() bool {
 
 	// If velocity is good, reset cycles behind and exit
 	if partitionVelocity <= consumerVelocity {
+		if(c.cyclesBehind != 0) {
+			log.Warningf("%s:%d  catching up: (resetting warning) CV %0.2f < PV %0.2f (warning #%d)",
+				c.topic, c.partID, consumerVelocity, partitionVelocity, c.cyclesBehind)
+		}
 		c.cyclesBehind = 0
 		return true
 	}
@@ -393,7 +397,7 @@ func (c *claim) healthCheck() bool {
 	// If were behind by too many cycles, then we should try to release the
 	// partition. If so, do this in a goroutine since it will involve calling out
 	// to Kafka and releasing the partition.
-	if c.cyclesBehind >= 3 {
+	if c.cyclesBehind >= 5 {
 		log.Warningf("%s:%d consumer unhealthy, releasing",
 			c.topic, c.partID)
 		go c.Release()
@@ -435,9 +439,11 @@ func average(vals []int64) float64 {
 		}
 		ct++
 	}
-	if ct == 0 {
+
+	if min == max || ct < 2 {
 		return 0
 	}
+
 	return float64(max-min) / float64(ct-1)
 }
 

--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -290,6 +290,11 @@ func (s *ClaimSuite) TestVelocity(c *C) {
 	c.Assert(s.cl.ConsumerVelocity(), Equals, float64(5))
 	s.cl.offsetLatestHistory = s.cl.offsetCurrentHistory
 	c.Assert(s.cl.PartitionVelocity(), Equals, s.cl.ConsumerVelocity())
+
+	s.cl.offsetCurrentHistory = [10]int64{21, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	c.Assert(s.cl.ConsumerVelocity(), Equals, float64(0))
+	s.cl.offsetLatestHistory = s.cl.offsetCurrentHistory
+	c.Assert(s.cl.PartitionVelocity(), Equals, s.cl.ConsumerVelocity())
 }
 
 func (s *ClaimSuite) TestHealthCheck(c *C) {


### PR DESCRIPTION
This will incorrectly mark partition unhealthy during partition health check

Updated unit tests to cover the scanario

Here is the output of NaN showing up on the log,

$ cat log | grep NaN | tail -1
2015/11/10 00:39:17 goscribe.server-request-tracing:13 consumer unhealthy: CV NaN < PV NaN (warning #1)
