### PR TITLE
Commit Upon Terminating Consumer

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -37,7 +37,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to construct consumer: %s", err)
 	}
-	defer consumer.Terminate()
+	defer consumer.Terminate(true)
 
 	// Now we can get the consumption channel. Messages will be available in this channel
 	// and you can consume from it in many different goroutines if your message processing

--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -224,9 +224,8 @@ func (s *ClaimSuite) TestCommitOffsets(c *C) {
 }
 
 func (s *ClaimSuite) TestCommitOutstanding(c *C) {
-	// Test that calling Commit/Release should commit any outstanding messages
-	// Test the commit message flow, ensuring that our offset only gets updated when
-	// we have properly committed messages
+	// Test that calling CommitOffsets should commit offsets for outstanding messages and
+	// updates claim tracking
 	c.Assert(s.Produce("test16", 0, "m1", "m2", "m3", "m4", "m5", "m6"), Equals, int64(5))
 	c.Assert(s.cl.updateOffsets(0), IsNil)
 	c.Assert(s.cl.offsets.Current, Equals, int64(0))
@@ -239,6 +238,8 @@ func (s *ClaimSuite) TestCommitOutstanding(c *C) {
 	c.Assert(s.cl.Commit(msg1), IsNil)
 	c.Assert(len(s.cl.tracking), Equals, 6)
 	c.Assert(s.cl.offsets.Current, Equals, int64(0))
+
+	// Commit the offsets....should update current offset and tracking for the claim
 	c.Assert(s.cl.CommitOffsets(), Equals, true)
 	c.Assert(s.cl.offsets.Current, Equals, int64(1))
 	c.Assert(len(s.cl.tracking), Equals, 5)

--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -217,12 +217,10 @@ func (s *ClaimSuite) TestRelease(c *C) {
 func (s *ClaimSuite) TestCommitOffsets(c *C) {
 	// Test that calling Release on a claim properly sets the flag and commits offsets
 	// for the partition
+	c.Assert(s.m.GetPartitionClaim("test16", 0).LastHeartbeat, Not(Equals), int64(0))
 	c.Assert(s.cl.Claimed(), Equals, true)
 	c.Assert(s.cl.CommitOffsets(), Equals, true)
-	c.Assert(s.cl.Claimed(), Equals, false)
-	c.Assert(s.m.waitForRsteps(1), Equals, 1)
-	c.Assert(s.m.GetPartitionClaim("test16", 0).LastHeartbeat, Equals, int64(0))
-	c.Assert(s.cl.CommitOffsets(), Equals, false)
+	c.Assert(s.cl.Claimed(), Equals, true)
 }
 
 func (s *ClaimSuite) TestCommitOutstanding(c *C) {

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -1,13 +1,12 @@
 package marshal
 
 import (
+	. "gopkg.in/check.v1"
 	"math/rand"
 	"sort"
 	"strconv"
 	"sync/atomic"
 	"time"
-
-	. "gopkg.in/check.v1"
 
 	"github.com/optiopay/kafka/kafkatest"
 	"github.com/optiopay/kafka/proto"
@@ -105,18 +104,18 @@ func (s *ConsumerSuite) TestMultiClaim(c *C) {
 	// we get all of the messages out
 	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
 	c.Assert(s.cn.tryClaimPartition(1), Equals, true)
-
-	// Produce 1000 messages to the two partitions
-	for i := 0; i < 1000; i++ {
+	numMessages := 100
+	// Produce numMessages messages to the two partitions
+	for i := 0; i < numMessages; i++ {
 		s.Produce("test16", i%2, strconv.Itoa(i))
 	}
 
-	// Now consume 1000 times and ensure we get exactly 1000 unique messages
+	// Now consume numMessages times and ensure we get exactly 1000 unique messages
 	results := make(map[string]bool)
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < numMessages; i++ {
 		results[string(s.cn.consumeOne().Value)] = true
 	}
-	c.Assert(len(results), Equals, 1000)
+	c.Assert(len(results), Equals, numMessages)
 }
 
 func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -90,9 +90,8 @@ func (s *ConsumerSuite) TestTerminateWithRelease(c *C) {
 	c.Assert(s.m.GetPartitionClaim(s.cn.topic, 0).LastHeartbeat, Equals, int64(0))
 }
 
-func (s *ConsumerSuite) TestTerminateWithCommit(c *C) {
-	// Termination is supposed to release active claims that we have, ensure that
-	// this happens
+func (s *ConsumerSuite) TestTerminateWithoutRelease(c *C) {
+	// Termination is supposed to commit the active claims without releasing the partition
 	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
 	c.Assert(s.cn.Terminate(false), Equals, true)
 	// Shouldn't release the claim


### PR DESCRIPTION
We need to update the currrent offset during both heartbeats and
when we terminate. That way we can commit the offsets back to Kafka.
This changes does that. It also includes a breaking change to the API
by changing Terminate to have an extra flag that indicates whether we
should release the partition or just commit the offsets without releasing
the partition. It should be noted that we will need to update some
dependent code once this is checked-in internally.

Added tests for the new code and made sure things pass.
