### PR TITLE
Implement topic claim

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -406,6 +406,12 @@ func (c *claim) healthCheck() bool {
 		return false
 	}
 
+	// In topic claim mode we don't do any velocity checking. It's up to the consumer
+	// to ensure they're claiming. TODO: Unclear if this is correct or not.
+	if c.options.ClaimEntireTopic {
+		return true
+	}
+
 	// If current has gone forward of the latest (which is possible, but unlikely)
 	// then we are by definition caught up
 	if c.offsets.Current >= c.offsets.Latest {


### PR DESCRIPTION
This adds a consumer option that instructs it to claim the entire topic.
This is useful in the sharded consumption design.

Fixes #2.

cc @DrTall @basharal
