### PR TITLE
close consumer channel upon termination

### DIFF
--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -223,6 +223,8 @@ func (c *Consumer) Terminate() bool {
 			claim.Release()
 		}
 	}
+
+	close(c.messages)
 	return true
 }
 


### PR DESCRIPTION
It makes sense to close the consumer channel upon termination. Otherwise, each client has to implement their quitting channel on top
