### PR TITLE
Remove log.Fatalf in double-claim

### DIFF
--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -84,9 +84,26 @@ func (s *ConsumerSuite) TestNewConsumer(c *C) {
 	c.Assert(cn.consumeOne().Value, DeepEquals, []byte("m2"))
 	c.Assert(cn.consumeOne().Value, DeepEquals, []byte("m3"))
 
-	// TODO: flesh out test, can create a second consumer and then see if it gets any
-	// partitions, etc.
-	// lots of things can be tested.
+	// Get consumer channel for this next test
+	chn := cn.ConsumeChannel()
+
+	// Terminate marshaler, ensure it terminates the consumer
+	s.m.Terminate()
+	c.Assert(s.m.Terminated(), Equals, true)
+	c.Assert(cn.Terminated(), Equals, true)
+
+	// Ensure that the channel has been closed
+	select {
+	case _, ok := <-chn:
+		c.Assert(ok, Equals, false)
+	default:
+		c.Assert(false, Equals, true)
+	}
+
+	// Now ensure we can't create a new consumer
+	cn, err = s.m.NewConsumer("test1", options)
+	c.Assert(cn, IsNil)
+	c.Assert(err, NotNil)
 }
 
 func (s *ConsumerSuite) TestTerminateWithRelease(c *C) {

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"sync/atomic"
 	"time"
 
 	"github.com/optiopay/kafka"
@@ -96,7 +95,7 @@ func NewMarshaler(clientID, groupID string, brokers []string) (*Marshaler, error
 
 	// Now start the metadata refreshing goroutine
 	go func() {
-		for atomic.LoadInt32(ws.quit) != 1 {
+		for !ws.Terminated() {
 			time.Sleep(<-ws.jitters)
 			log.Infof("Refreshing topic metadata.")
 			ws.refreshMetadata()


### PR DESCRIPTION
This fixes the plumbing such that when Marshal is terminated, it is
able to pass that termination on to the consumers. This also fixes some
further plumbing to ensure that we close the channels when we terminate.

This makes Marshal less likely to blow up your binary when it gets mad,
which is generally considered a good thing.

Fixes https://github.com/dropbox/marshal/issues/23.
